### PR TITLE
adds configurable aliases

### DIFF
--- a/swmap/i18n/en.lua
+++ b/swmap/i18n/en.lua
@@ -29,5 +29,8 @@ return {
     DisplayVersion = "Display script version?",
     DisplayModelName = "Display model's name?",
     FullScreenOptions = "Options for Full Screen only",
-    DisplayAliases = "Use switch aliases?"
+    SwitchExpansionTitleWithAlias = "Switch labels (alias)",
+    YesWithAlias = "Yes (alias)",
+    Yes = "Yes",
+    No = "No",
 }

--- a/swmap/i18n/en.lua
+++ b/swmap/i18n/en.lua
@@ -28,5 +28,6 @@ return {
     Note2 = "Note2",
     DisplayVersion = "Display script version?",
     DisplayModelName = "Display model's name?",
-    FullScreenOptions = "Options for Full Screen only"
+    FullScreenOptions = "Options for Full Screen only",
+    DisplayAliases = "Use switch aliases?"
 }

--- a/swmap/main.lua
+++ b/swmap/main.lua
@@ -203,6 +203,7 @@ local function defaultConfig()
         TextColor = nil,
         DisplayVersion = true,
         DisplayModelName = true,
+        DisplayAliases = false,
         Note1 = "",
         Note2 = "",
         NoteColor = nil,
@@ -325,7 +326,10 @@ local function paint(widget)
     -- next legends (on top)
     for _, specs in pairs(widget.radio) do
         local name = specs["name"] or ""
-        local alias = specs["alias"] or specs["name"] or ""
+        local alias = name
+        if widget.DisplayAliases then
+            alias = specs["alias"] or specs["name"] or ""
+        end
         lcd.color(widget.TextColor or getDefaultTextColor())
         if specs["lines"] then
             addLegend(widget[name .. "text"] or "", alias, specs["lines"], specs["align"],
@@ -400,7 +404,39 @@ local function event(widget, category, value, x, y)
     end
 end
 
-
+local function fillSwitchPanel(panel, widget, hasAliases)
+    local line
+    if hasAliases then
+        line = panel:addLine(STR("DisplayAliases"))
+        form.addBooleanField(line, nil,
+            function() return widget.DisplayAliases end,
+            function(value)
+                widget.DisplayAliases = value
+                panel:clear()
+                fillSwitchPanel(panel, widget, hasAliases)
+            end)
+    end
+    local isFirst
+    if type(widget.radio) == "table" then
+        for _, specs in pairs(widget.radio) do
+            local name = specs["name"] or ""
+            local alias = name
+            if widget.DisplayAliases then
+                alias = specs["alias"] or specs["name"] or ""
+            end
+            if specs.lines then -- no lines means no legend or disabled switches
+                line = panel:addLine(STR_TYPE_LABEL(specs.type, alias))
+                local textField = form.addTextField(line, nil,
+                    function() return widget[name .. "text"] or "" end,
+                    function(value) widget[name .. "text"] = value end)
+                if isFirst == nil then
+                    textField:focus()
+                    isFirst = false
+                end
+            end
+        end
+    end
+end
 -- **************************************************************************************
 -- ***		     configure widget	 	   		                                      ***
 -- *** Clicking the widget configure option triggers this handler.                    ***
@@ -422,6 +458,16 @@ local function configure(widget)
         return true
     end
     local isEmpty = _checkIfEmpty() -- cache
+    local function _checkIfAliases()
+        if type(widget.radio) ~= "table" then return false end
+        for _, specs in pairs(widget.radio) do
+            if specs["alias"] then
+                return true
+            end
+        end
+        return false
+    end
+    local hasAliases = _checkIfAliases() -- cache
 
     local function loadTemplate(basename)
         -- erase first
@@ -485,23 +531,8 @@ local function configure(widget)
         function(value) widget.TextColor = value ~= getDefaultTextColor() and value or nil end)
 
     panel = form.addExpansionPanel(STR("SwitchExpansionTitle"))
-    local isFirst
-    if type(widget.radio) == "table" then
-        for _, specs in pairs(widget.radio) do
-            local name = specs["name"] or ""
-            local alias = specs["alias"] or specs["name"] or ""
-            if specs.lines then -- no lines means no legend or disabled switches
-                line = panel:addLine(STR_TYPE_LABEL(specs.type, alias))
-                local textField = form.addTextField(line, nil,
-                    function() return widget[name .. "text"] or "" end,
-                    function(value) widget[name .. "text"] = value end)
-                if isFirst == nil then
-                    textField:focus()
-                    isFirst = false
-                end
-            end
-        end
-    end
+    fillSwitchPanel(panel, widget, hasAliases)
+
     local fullScreenPanel = form.addExpansionPanel(STR("FullScreenOptions"))
     line = fullScreenPanel:addLine(STR("DisplayModelName"))
     form.addBooleanField(line, nil, function() return widget.DisplayModelName end,
@@ -632,6 +663,7 @@ local function write(widget)
     end
     append("DisplayVersion", widget.DisplayVersion)
     append("DisplayModelName", widget.DisplayModelName)
+    append("DisplayAliases", widget.DisplayAliases)
     append("Note1", quote(widget.Note1))
     append("Note2", quote(widget.Note2))
     for key, value in pairs(widget) do

--- a/swmap/main.lua
+++ b/swmap/main.lua
@@ -168,6 +168,12 @@ local function readConfiguration(basename)
     local chunk = loadfile(getConfigurationFilePath(basename), "bt", { lcd = lcd }) -- load the config file passing only the lcd global variable
     if chunk then
         local config = chunk()
+        if config and config.DisplaySwitchNames then
+            if type(config.DisplaySwitchNames) == "boolean" then
+                -- convert old boolean to new integer for backward compatibility
+                config.DisplaySwitchNames = config.DisplaySwitchNames and 1 or 0
+            end
+        end
         return config
     else
         -- might be normal for a new model
@@ -199,7 +205,7 @@ end
 local function defaultConfig()
     local widget = {
         DisplayAll = true,
-        DisplaySwitchNames = true,
+        DisplaySwitchNames = 0, -- 0: no, 1: yes, 2: yes with aliases if available
         TextColor = nil,
         DisplayVersion = true,
         DisplayModelName = true,
@@ -294,7 +300,7 @@ local function paint(widget)
             if not align and x < w / 2 then align = TEXT_LEFT end
             if not align and x >= w / 2 then align = TEXT_RIGHT end
             local labelOffsetX = 0
-            if widget.DisplaySwitchNames and prefix and prefix ~= "" then
+            if widget.DisplaySwitchNames > 0 and prefix and prefix ~= "" then
                 lcd.font(FONT_S_BOLD and FONT_S_BOLD or FONT_S)
                 local pw = lcd.getTextSize(prefix .. " ")
                 if align == TEXT_RIGHT then
@@ -327,7 +333,7 @@ local function paint(widget)
     for _, specs in pairs(widget.radio) do
         local name = specs["name"] or ""
         local alias = name
-        if widget.DisplayAliases then
+        if widget.DisplaySwitchNames == 2 then
             alias = specs["alias"] or specs["name"] or ""
         end
         lcd.color(widget.TextColor or getDefaultTextColor())
@@ -406,26 +412,17 @@ end
 
 local function fillSwitchPanel(panel, widget, hasAliases)
     local line
-    if hasAliases then
-        line = panel:addLine(STR("DisplayAliases"))
-        form.addBooleanField(line, nil,
-            function() return widget.DisplayAliases end,
-            function(value)
-                widget.DisplayAliases = value
-                panel:clear()
-                fillSwitchPanel(panel, widget, hasAliases)
-            end)
-    end
     local isFirst
     if type(widget.radio) == "table" then
         for _, specs in pairs(widget.radio) do
             local name = specs["name"] or ""
-            local alias = name
-            if widget.DisplayAliases then
-                alias = specs["alias"] or specs["name"] or ""
-            end
+            local alias = specs["alias"]
             if specs.lines then -- no lines means no legend or disabled switches
-                line = panel:addLine(STR_TYPE_LABEL(specs.type, alias))
+                if alias then
+                    line = panel:addLine(STR_TYPE_LABEL(specs.type, name .. " (" .. alias .. ")"))
+                else
+                    line = panel:addLine(STR_TYPE_LABEL(specs.type, name))
+                end
                 local textField = form.addTextField(line, nil,
                     function() return widget[name .. "text"] or "" end,
                     function(value) widget[name .. "text"] = value end)
@@ -522,7 +519,12 @@ local function configure(widget)
         function(value) widget.DisplayAll = value end)
 
     line = form.addLine(STR("DisplaySwitchNames"))
-    form.addBooleanField(line, nil, function() return widget.DisplaySwitchNames end,
+    local displaySwitchNamesChoices = { { STR("No"), 0 }, { STR("Yes"), 1 } }
+    if hasAliases then
+        table.insert(displaySwitchNamesChoices, { STR("YesWithAlias"), 2 })
+    end
+    form.addChoiceField(line, nil, displaySwitchNamesChoices,
+        function() return widget.DisplaySwitchNames end,
         function(value) widget.DisplaySwitchNames = value end)
 
     line = form.addLine(STR("TextColor"))
@@ -530,7 +532,7 @@ local function configure(widget)
         function() return widget.TextColor or getDefaultTextColor() end,
         function(value) widget.TextColor = value ~= getDefaultTextColor() and value or nil end)
 
-    panel = form.addExpansionPanel(STR("SwitchExpansionTitle"))
+    panel = form.addExpansionPanel(hasAliases and STR("SwitchExpansionTitleWithAlias") or STR("SwitchExpansionTitle"))
     fillSwitchPanel(panel, widget, hasAliases)
 
     local fullScreenPanel = form.addExpansionPanel(STR("FullScreenOptions"))

--- a/swmap/main.lua
+++ b/swmap/main.lua
@@ -523,6 +523,9 @@ local function configure(widget)
     if hasAliases then
         table.insert(displaySwitchNamesChoices, { STR("YesWithAlias"), 2 })
     end
+    if widget.DisplaySwitchNames > #displaySwitchNamesChoices then
+        widget.DisplaySwitchNames = #displaySwitchNamesChoices -- just in case
+    end
     form.addChoiceField(line, nil, displaySwitchNamesChoices,
         function() return widget.DisplaySwitchNames end,
         function(value) widget.DisplaySwitchNames = value end)

--- a/swmap/main.lua
+++ b/swmap/main.lua
@@ -205,7 +205,7 @@ end
 local function defaultConfig()
     local widget = {
         DisplayAll = true,
-        DisplaySwitchNames = 0, -- 0: no, 1: yes, 2: yes with aliases if available
+        DisplaySwitchNames = 1, -- 0: no, 1: yes, 2: yes with aliases if available
         TextColor = nil,
         DisplayVersion = true,
         DisplayModelName = true,
@@ -519,16 +519,19 @@ local function configure(widget)
         function(value) widget.DisplayAll = value end)
 
     line = form.addLine(STR("DisplaySwitchNames"))
-    local displaySwitchNamesChoices = { { STR("No"), 0 }, { STR("Yes"), 1 } }
     if hasAliases then
-        table.insert(displaySwitchNamesChoices, { STR("YesWithAlias"), 2 })
+        local displaySwitchNamesChoices = { { STR("No"), 0 }, { STR("Yes"), 1 }, { STR("YesWithAlias"), 2 } }
+        if widget.DisplaySwitchNames > #displaySwitchNamesChoices then
+            widget.DisplaySwitchNames = #displaySwitchNamesChoices -- just in case
+        end
+        form.addChoiceField(line, nil, displaySwitchNamesChoices,
+            function() return widget.DisplaySwitchNames end,
+            function(value) widget.DisplaySwitchNames = value end)
+    else
+        form.addBooleanField(line, nil,
+            function() return widget.DisplaySwitchNames >= 1 end,
+            function(value) widget.DisplaySwitchNames = value and 1 or 0 end)
     end
-    if widget.DisplaySwitchNames > #displaySwitchNamesChoices then
-        widget.DisplaySwitchNames = #displaySwitchNamesChoices -- just in case
-    end
-    form.addChoiceField(line, nil, displaySwitchNamesChoices,
-        function() return widget.DisplaySwitchNames end,
-        function(value) widget.DisplaySwitchNames = value end)
 
     line = form.addLine(STR("TextColor"))
     form.addColorField(line, nil,

--- a/swmap/main.lua
+++ b/swmap/main.lua
@@ -168,7 +168,7 @@ local function readConfiguration(basename)
     local chunk = loadfile(getConfigurationFilePath(basename), "bt", { lcd = lcd }) -- load the config file passing only the lcd global variable
     if chunk then
         local config = chunk()
-        if config and config.DisplaySwitchNames then
+        if config and config.DisplaySwitchNames ~= nil then
             if type(config.DisplaySwitchNames) == "boolean" then
                 -- convert old boolean to new integer for backward compatibility
                 config.DisplaySwitchNames = config.DisplaySwitchNames and 1 or 0


### PR DESCRIPTION
Do not merge, this is a test version available on configurable-aliases branch on my repo. This is for testing and get an idea for naming.
Configuration toggle is in the switch panel, it shows only if there is an alias defined in the radio file (so xlite and xe only). It default to false.
Configuration is saved in the model file.